### PR TITLE
fix servo scaling

### DIFF
--- a/phaser.py
+++ b/phaser.py
@@ -342,10 +342,10 @@ class Phaser(Module):
                     If(
                         servo_enable,
                         self.dac.data[2 * t][ch].eq(
-                            servo_dsp_i.p >> len(self.dac.data[2 * t][ch] - 1)
+                            servo_dsp_i.p >> len(self.dac.data[2 * t][ch]) - 1
                         ),
                         self.dac.data[2 * t + 1][ch].eq(
-                            servo_dsp_q.p >> len(self.dac.data[2 * t][ch] - 1)
+                            servo_dsp_q.p >> len(self.dac.data[2 * t][ch]) - 1
                         ),
                     ),
                 ]


### PR DESCRIPTION
That was a bug.. I checked that you can get full-scale output now with 10 V input and IIR P gain of -1.999. I don't know where the inversion comes from.