### PR TITLE
Fix ADC Missed 1 Bit Error

### DIFF
--- a/adc.py
+++ b/adc.py
@@ -50,7 +50,7 @@ class Adc(Module):
         self.sdo2n = sdo2n = Signal()  # inverted input
         self.ddr_clk_synth = ddr_clk_synth = Signal(
             6, reset=0b000111
-        )  # signal to generate a 10ns period clock
+        )  # signal to generate a 4 ns * 3 = 12 ns period clock
 
         if pins != None:
             self.specials += [
@@ -59,7 +59,7 @@ class Adc(Module):
                 DifferentialOutput(~cnvn, pins.cnvn_n, pins.cnvn_p),  # swapped
                 DifferentialInput(pins.sdo_p[0], pins.sdo_n[0], sdo[0]),
                 DifferentialInput(pins.sdo_n[1], pins.sdo_p[1], sdo2n),  # swapped
-                DDROutput(ddr_clk_synth[1], ddr_clk_synth[0], sck, ClockSignal("sys")),
+                DDROutput(~ddr_clk_synth[1], ~ddr_clk_synth[0], sck, ClockSignal("sys")),
             ]
 
         self.comb += [

--- a/phaser.py
+++ b/phaser.py
@@ -238,11 +238,11 @@ class Phaser(Module):
             self.decoder.get("spi_datr", "read").eq(self.spi.reg.pdi),
         ]
 
-        # 32 ns t_cnvh, 12 ns t_conv/t_DCNVSCKL, 192 ns data transfer, 24 ns t_rtt/tDSCKLCNVH
+        # 32 ns t_cnvh, 16 ns t_conv/t_DCNVSCKL, 192 ns data transfer, 20 ns t_rtt/tDSCKLCNVH
         # Note that there is one extra cycle (4 ns) at the end of a transaction.
         # Total: 264 ns -> 3.788 MSps
         adc_parameters = AdcParams(
-            width=16, channels=2, lanes=2, t_cnvh=8, t_conv=3, t_rtt=6
+            width=16, channels=2, lanes=2, t_cnvh=8, t_conv=4, t_rtt=5
         )
 
         self.submodules.adc = adc = Adc(platform.request("adc"), adc_parameters)


### PR DESCRIPTION
# Description of Changes
I found this when I was trying to add a register to read out the ADC data for artiq_sinara_tester for production test. There is one bit that is missed and not read for each transaction. This is due to SCK in the current gateware not being idle HIGH as specified in the LTC2323-16 datasheet. See below for reference.

![image](https://github.com/user-attachments/assets/4d6faa64-bb95-4e5b-9b7a-5821df87f8d0)
Note: Timing Diagram from LTC2323-16 datasheet

To fix it, I flipped the SCK period and adjust the t_conv(3->4) and t_rtt(6->5) accordingly to meet the timings,

## Original Code Captured Waveform

I probed the ADC input directly at the input capacitor. That is around -557.875mV across. Given Vref of 4.096V, the LSB size is 125uV (given in the datasheet Transfer Function Section). Therefore, if it is read correctly, the readings should be 0xEE91. However, the value read is 0xF748 instead. This is due to the last bit is not clocked in by the gateware. 

Notice the SCK here in the original code is idle low. Since the ADC data is clocked out at the falling edge, at the end of the transaction, there is a bit missed and is not read by the gateware (circled in red). See the captured example waveform below.

To verify the gateware did missed the last bit, I added a phaser [register](https://github.com/linuswck/phaser/commit/99135bfb15bb1610c2a6367e950c6f1963d5f80b) to access the adc readings via Artiq. The gateware did miss the last bit of the adc readings. 

![image](https://github.com/user-attachments/assets/3b037049-89d0-4ce3-a993-5f642c04c6c2)
Note: SCK is slowed down to account for the logic analyzer bandwidth.

## PR Code Captured Waveforms

Flipping the output of SCK can already fix this issue. After the change, it now reads all the 16 bit readings and close to the theoretical value(0xEE91). See the captured waveform below. 
![image](https://github.com/user-attachments/assets/e3b97b35-0ab6-40d9-a2de-27a5e606ca0f)
Note: SCK is slowed down to account for the logic analyzer bandwidth.

See the captured waveform below for the t_DCNVSCKL timing requirement at the original SCK frequency(83.3MHz). SCK stays quiet for at least 10ns after the falling edge of CNVN.
![SDS2504X Plus_PNG_15](https://github.com/user-attachments/assets/9ce6d8f4-d967-4622-89ea-acc770c3f95d)
Note: CNVN: IC24's Output | SCK+: R5 ADC_SCK_P Net

The sampling frequency remains unchanged.
![SDS2504X Plus_PNG_16](https://github.com/user-attachments/assets/622ae73e-f8de-4611-8960-b27d3cb20bcb)

At the original SCK speed with the PR fix, I read the adc readings via Artiq with the newly added phaser [register](https://github.com/linuswck/phaser/commit/99135bfb15bb1610c2a6367e950c6f1963d5f80b). All 16 bits are present and the value read is closed to the theoretical value. So, the gateware is sampling on the right edge.