### PR TITLE
fix iir clamping

### DIFF
--- a/iir.py
+++ b/iir.py
@@ -5,7 +5,6 @@
 # Note: Migen translates the "out of range" pc mux selector to the last valid mux input.
 
 from ast import Constant
-
 from migen import *
 
 N_COEFF = 3  # [b0, b1, a1] number of coefficients for a first order iir
@@ -16,9 +15,9 @@ class Dsp(Module):
         # xilinx dsp architecture (subset)
         self.a = a = Signal((25, True), reset_less=True)
         self.b = b = Signal((18, True), reset_less=True)
-        self.c = c = Signal((len(a) + len(b), True), reset_less=True)
+        self.c = c = Signal((41, True), reset_less=True)
         self.mux_p = mux_p = Signal()  # accumulator mux
-        self.m = m = Signal((len(a) + len(b), True), reset_less=True)
+        self.m = m = Signal((43, True), reset_less=True)
         self.p = p = Signal((48, True), reset_less=True)
         self.sync += [m.eq(a * b), p.eq(m + c), If(mux_p, p.eq(m + p))]
 
@@ -78,7 +77,7 @@ class Iir(Module):
         self.submodules.dsp = dsp = Dsp()
         assert w_data <= len(dsp.b)
         assert w_coeff <= len(dsp.a)
-        shift_c = len(dsp.a) + len(dsp.b) - w_data
+        shift_c = len(dsp.a) + len(dsp.b) - w_data - (w_data - log2_a0)
         shift_a = len(dsp.a) - w_coeff
         shift_b = len(dsp.b) - w_data
         # +1 from standard sign bit
@@ -133,7 +132,7 @@ class Iir(Module):
             ch_profile_last_ch.eq(ch_profile[channel_index - 1]),
             [o.eq(y1[ch_profile[ch]][ch]) for ch, o in enumerate(outp)],
             # clipping to positive output range
-            y0_clipped.eq(dsp.p >> (shift_c - (w_data - log2_a0))),
+            y0_clipped.eq(dsp.p >> shift_c),
             If(
                 dsp.p[-n_sign:] != 0,  # if out of output range
                 y0_clipped.eq((1 << w_data - 1) - 1),

--- a/iir.py
+++ b/iir.py
@@ -79,8 +79,6 @@ class Iir(Module):
         assert w_data <= len(dsp.b)
         assert w_coeff <= len(dsp.a)
         shift_c = len(dsp.a) + len(dsp.b) - w_data
-        print(shift_c)
-        print(w_data)
         shift_a = len(dsp.a) - w_coeff
         shift_b = len(dsp.b) - w_data
         # +1 from standard sign bit

--- a/iir.py
+++ b/iir.py
@@ -5,6 +5,7 @@
 # Note: Migen translates the "out of range" pc mux selector to the last vaid mux input.
 
 from ast import Constant
+
 from migen import *
 
 N_COEFF = 3  # [b0, b1, a0] number of coefficients for a first order iir
@@ -18,8 +19,14 @@ class Dsp(Module):
         self.c = c = Signal((48, True), reset_less=True)
         self.mux_p = mux_p = Signal()  # accumulator mux
         self.m = m = Signal((48, True), reset_less=True)
+        self.mult_out = mult_out = Signal.like(m)
         self.p = p = Signal((48, True), reset_less=True)
-        self.sync += [m.eq(a * b), p.eq(m + c), If(mux_p, p.eq(m + p))]
+        self.comb += mult_out.eq(a * b)
+        self.sync += [
+            m.eq(Cat(mult_out, [mult_out[-1]] * (len(m) - len(a) - len(b)))),
+            p.eq(m + c),
+            If(mux_p, p.eq(m + p)),
+        ]
 
 
 class Iir(Module):
@@ -50,7 +57,7 @@ class Iir(Module):
 
         ###
 
-        # Making these registers reset less results in worsend timing.
+        # Making these registers reset less results in worse timing.
         # y1 register unique for each profile
         y1 = Array(
             Array(Signal((w_data, True)) for _ in range(n_channels))
@@ -73,7 +80,7 @@ class Iir(Module):
         # 2(4) ->                                         p2=p1+m2
         # 3(5) ->                                                      retrieve data y0=clip(p2)?hold
         step = Signal(2)  # computation step
-        ch_profile_last_ch = Signal(max=n_profiles + 1)  # auxillary signal for muxing
+        ch_profile_last_ch = Signal(max=n_profiles + 1)  # auxiliary signal for muxing
         self.submodules.dsp = dsp = Dsp()
         assert w_data <= len(dsp.b)
         assert w_coeff <= len(dsp.a)
@@ -91,7 +98,14 @@ class Iir(Module):
             dsp.b.eq(
                 x[channel_index][step] << shift_b
             ),  # overwritten later if at step==2
-            dsp.c.eq(Cat(c_rounding_offset, offset[profile_index][channel_index])),
+            dsp.c.eq(
+                Cat(
+                    c_rounding_offset,
+                    offset[profile_index][channel_index],
+                    [offset[profile_index][channel_index][-1]]  # extend sign bit
+                    * (len(dsp.c) - len(dsp.a) - len(dsp.b) + (w_data - log2_a0)),
+                )
+            ),
             If(
                 stb_in & ~busy,
                 busy.eq(1),

--- a/iir.py
+++ b/iir.py
@@ -22,7 +22,9 @@ class Dsp(Module):
         self.p = p = Signal((48, True), reset_less=True)
         self.comb += mult_out.eq(a * b)
         self.sync += [
-            m.eq(Cat(mult_out, [mult_out[-1]] * (len(m) - len(a) - len(b)))),
+            m.eq(
+                Cat(mult_out, [mult_out[-1]] * (len(m) - len(a) - len(b)))
+            ),  # extend sign bit
             p.eq(m + c),
             If(mux_p, p.eq(m + p)),
         ]

--- a/iir.py
+++ b/iir.py
@@ -1,11 +1,10 @@
-# First order IIR filter for multiple channels and profiles with one DSP and no blockram.
+# First order IIR filter for multiple channels and profiles with one DSP and no block ram.
 # DSP block with MSB aligned inputs and "round half down" rounding.
 #
 #
-# Note: Migen translates the "out of range" pc mux selector to the last vaid mux input.
+# Note: Migen translates the "out of range" pc mux selector to the last valid mux input.
 
 from ast import Constant
-
 from migen import *
 
 N_COEFF = 3  # [b0, b1, a0] number of coefficients for a first order iir

--- a/iir.py
+++ b/iir.py
@@ -1,13 +1,14 @@
-# First order IIR filter for multiple channels and profiles with one DSP and no block ram.
+# First order IIR filter for multiple channels and profiles with one DSP and no blockram.
 # DSP block with MSB aligned inputs and "round half down" rounding.
 #
 #
 # Note: Migen translates the "out of range" pc mux selector to the last valid mux input.
 
 from ast import Constant
+
 from migen import *
 
-N_COEFF = 3  # [b0, b1, a0] number of coefficients for a first order iir
+N_COEFF = 3  # [b0, b1, a1] number of coefficients for a first order iir
 
 
 class Dsp(Module):
@@ -15,19 +16,11 @@ class Dsp(Module):
         # xilinx dsp architecture (subset)
         self.a = a = Signal((25, True), reset_less=True)
         self.b = b = Signal((18, True), reset_less=True)
-        self.c = c = Signal((48, True), reset_less=True)
+        self.c = c = Signal((len(a) + len(b), True), reset_less=True)
         self.mux_p = mux_p = Signal()  # accumulator mux
-        self.m = m = Signal((48, True), reset_less=True)
-        self.mult_out = mult_out = Signal.like(m)
+        self.m = m = Signal((len(a) + len(b), True), reset_less=True)
         self.p = p = Signal((48, True), reset_less=True)
-        self.comb += mult_out.eq(a * b)
-        self.sync += [
-            m.eq(
-                Cat(mult_out, [mult_out[-1]] * (len(m) - len(a) - len(b)))
-            ),  # extend sign bit
-            p.eq(m + c),
-            If(mux_p, p.eq(m + p)),
-        ]
+        self.sync += [m.eq(a * b), p.eq(m + c), If(mux_p, p.eq(m + p))]
 
 
 class Iir(Module):
@@ -85,7 +78,9 @@ class Iir(Module):
         self.submodules.dsp = dsp = Dsp()
         assert w_data <= len(dsp.b)
         assert w_coeff <= len(dsp.a)
-        shift_c = len(dsp.a) + len(dsp.b) - w_data - (w_data - log2_a0)
+        shift_c = len(dsp.a) + len(dsp.b) - w_data
+        print(shift_c)
+        print(w_data)
         shift_a = len(dsp.a) - w_coeff
         shift_b = len(dsp.b) - w_data
         # +1 from standard sign bit
@@ -99,14 +94,7 @@ class Iir(Module):
             dsp.b.eq(
                 x[channel_index][step] << shift_b
             ),  # overwritten later if at step==2
-            dsp.c.eq(
-                Cat(
-                    c_rounding_offset,
-                    offset[profile_index][channel_index],
-                    [offset[profile_index][channel_index][-1]]  # extend sign bit
-                    * (len(dsp.c) - len(dsp.a) - len(dsp.b) + (w_data - log2_a0)),
-                )
-            ),
+            dsp.c.eq(Cat(c_rounding_offset, offset[profile_index][channel_index])),
             If(
                 stb_in & ~busy,
                 busy.eq(1),
@@ -147,7 +135,7 @@ class Iir(Module):
             ch_profile_last_ch.eq(ch_profile[channel_index - 1]),
             [o.eq(y1[ch_profile[ch]][ch]) for ch, o in enumerate(outp)],
             # clipping to positive output range
-            y0_clipped.eq(dsp.p >> shift_c),
+            y0_clipped.eq(dsp.p >> (shift_c - (w_data - log2_a0))),
             If(
                 dsp.p[-n_sign:] != 0,  # if out of output range
                 y0_clipped.eq((1 << w_data - 1) - 1),


### PR DESCRIPTION
The clamping mechanism in the IIR was broken. It would clamp the positive side to positive fullscale but actually flip a negative output to positive fullsacale instead of clamping at 0 as intended originally.

The problem was that apparently the negative words in the DSP registers don't get their sign bit extended to the full register sizes. Therefore the MSB of the output never changed. I added manual replication of the sign bit to fill the registers. Now both sides of clamping work as intended.

DSP usage and timing didn't change.